### PR TITLE
fixed scroll sensitivity

### DIFF
--- a/fractals/gpu-accelerated/fractal.js
+++ b/fractals/gpu-accelerated/fractal.js
@@ -57,7 +57,7 @@ canvas.onwheel = function(e) {
     var zf = zoomFrame;
     var mc = mouseCoords;
     var [oldX, oldY] = zf.pixToCoord(mc.i, mc.j);
-    var newZoom = zf.zoom * Math.exp(0.1*e.deltaY);
+    var newZoom = zf.zoom * Math.exp(0.1*Math.sign(e.deltaY));
     // this transformation ensures that the canvas pixel
     // the mouse is pointing at maps to the same (x,y)
     // coordinate in both the old/new frames for "smooth"

--- a/fractals/single-thread/fractal.js
+++ b/fractals/single-thread/fractal.js
@@ -56,7 +56,8 @@ canvas.onwheel = function(e) {
     var zf = zoomFrame;
     var mc = mouseCoords;
     var [oldX, oldY] = zf.pixToCoord(mc.i, mc.j);
-    var newZoom = zf.zoom * Math.exp(0.1*e.deltaY);
+    //var newZoom = zf.zoom * Math.exp(0.1*e.deltaY);
+    var newZoom = zf.zoom * Math.exp(0.1*Math.sign(e.deltaY));
     // this transformation ensures that the canvas pixel
     // the mouse is pointing at maps to the same (x,y)
     // coordinate in both the old/new frames for "smooth"


### PR DESCRIPTION
Different browsers have different levels of scroll sensitivity, so this makes it browser-agnostic by only using the sign of the scroll direction to change the zoom by a fixed power of `e^0.1 = 1.105` for each click of the scroll wheel.